### PR TITLE
Fix incorrect icon type import in Button component

### DIFF
--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { DivideIcon as LucideIcon } from 'lucide-react';
+import type { LucideIcon } from 'lucide-react';
 
 interface ButtonProps {
   children: React.ReactNode;


### PR DESCRIPTION
## Summary
- use proper `LucideIcon` type import in `Button`

## Testing
- `npm run lint` *(fails: unexpected any and unused vars)*

------
https://chatgpt.com/codex/tasks/task_e_6879339ea644833184839a9479d7f1b6